### PR TITLE
Upgrade robomimic from 0.2.0 to 0.5.0

### DIFF
--- a/libero/lifelong/datasets.py
+++ b/libero/lifelong/datasets.py
@@ -35,7 +35,10 @@ def get_dataset(
     for modality_name, modality_list in obs_modality.items():
         all_obs_keys += modality_list
     shape_meta = FileUtils.get_shape_metadata_from_dataset(
-        dataset_path=dataset_path, all_obs_keys=all_obs_keys, verbose=False
+        dataset_config={"path": dataset_path},
+        action_keys=["actions"],
+        all_obs_keys=all_obs_keys,
+        verbose=False,
     )
 
     seq_len = seq_len
@@ -43,7 +46,9 @@ def get_dataset(
     dataset = SequenceDataset(
         hdf5_path=dataset_path,
         obs_keys=shape_meta["all_obs_keys"],
+        action_keys=["actions"],
         dataset_keys=["actions"],
+        action_config={"actions": {"normalization": None}},
         load_next_obs=False,
         frame_stack=frame_stack,
         seq_length=seq_len,  # length-10 temporal sequences
@@ -53,10 +58,15 @@ def get_dataset(
         goal_mode=None,
         hdf5_cache_mode=hdf5_cache_mode,  # cache dataset in memory to avoid repeated file i/o
         hdf5_use_swmr=False,
-        hdf5_normalize_obs=None,
+        hdf5_normalize_obs=False,
         filter_by_attribute=filter_key,  # can optionally provide a filter key here
     )
     return dataset, shape_meta
+
+
+def _cast_obs_to_float32(obs_dict):
+    """Cast all numpy arrays in obs dict to float32 for model compatibility."""
+    return {k: v.astype(np.float32) if isinstance(v, np.ndarray) else v for k, v in obs_dict.items()}
 
 
 class SequenceVLDataset(Dataset):
@@ -71,6 +81,7 @@ class SequenceVLDataset(Dataset):
 
     def __getitem__(self, idx):
         return_dict = self.sequence_dataset.__getitem__(idx)
+        return_dict["obs"] = _cast_obs_to_float32(ObsUtils.process_obs_dict(return_dict["obs"]))
         return_dict["task_emb"] = self.task_emb
         return return_dict
 
@@ -123,6 +134,7 @@ class GroupedTaskDataset(Dataset):
     def __getitem__(self, idx):
         oi, oti = self.__get_original_task_idx(idx)
         return_dict = self.sequence_datasets[oti].__getitem__(oi)
+        return_dict["obs"] = _cast_obs_to_float32(ObsUtils.process_obs_dict(return_dict["obs"]))
         return_dict["task_emb"] = self.task_embs[oti]
         return return_dict
 

--- a/libero/lifelong/models/modules/data_augmentation.py
+++ b/libero/lifelong/models/modules/data_augmentation.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
 
-from robomimic.models.base_nets import CropRandomizer
+from robomimic.models.obs_core import CropRandomizer
 
 
 class IdentityAug(nn.Module):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@
  numpy==1.22.4 
  wandb==0.13.1 
  easydict==1.9 
- transformers==4.21.1
+ transformers==4.41.2
  opencv-python==4.6.0.66 
- robomimic==0.2.0 
+ git+https://github.com/ARISE-Initiative/robomimic.git
  einops==0.4.1
  thop==0.1.1-2209072238
  robosuite==1.4.0


### PR DESCRIPTION
## Summary

- Upgrades robomimic to 0.5.0 (via GitHub, not on PyPI) to enable Diffusion Policy support (#3)
- Fixes 3 breaking API changes from robomimic 0.2.0 → 0.5.0
- Updates `transformers` to 4.41.2 (required by robomimic 0.5.0)

## Breaking changes fixed

| Change | File |
|---|---|
| `CropRandomizer` moved: `base_nets` → `obs_core` | `data_augmentation.py` |
| `get_shape_metadata_from_dataset()` new signature: `dataset_config` dict + required `action_keys` | `datasets.py` |
| `SequenceDataset` requires `action_keys`, `action_config`; no longer auto-processes obs | `datasets.py` |

## Test plan

- [x] All robomimic imports pass
- [x] Training runs successfully (bc_rnn_policy, 1 epoch, LIBERO_OBJECT)
- [x] Eval obs processing (HWC→CHW, float32 cast) works correctly
- [ ] Verify bc_transformer_policy and bc_vilt_policy training

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)